### PR TITLE
Cleanup nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,10 @@ http {
     # openssl genpkey -genparam -algorithm DH 
     # -out /etc/letsencrypt/live/davydehaas.nl/dhparam4096.pem -pkeyopt dh_paramgen_prime_len:4096
     
+    # Set the certificate
+    ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
+    ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
+    
     ssl_stapling                on;
     ssl_stapling_verify         on;
     
@@ -41,10 +45,6 @@ http {
         
         # The server name that will be redirected
         server_name             davydehaas.nl;
-        
-        # Set the certificate
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
 
         location / {
             # Pass the request to a specific ip and port
@@ -61,10 +61,7 @@ http {
         listen 443 ssl http2;
 
         server_name             jenkins.davydehaas.nl;
-
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
+        
         location / {
             proxy_pass          http://127.0.0.1:4000;
             proxy_redirect      http://127.0.0.1:4000 https://jenkins.davydehaas.nl;
@@ -84,9 +81,6 @@ http {
 
         server_name             sonarqube.davydehaas.nl;
 
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:9000;
             proxy_redirect      off;
@@ -101,9 +95,6 @@ http {
         listen 443 ssl http2;
 
         server_name             kubernetes.davydehaas.nl;
-
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
 
         location / {
             proxy_pass          http://127.0.0.1:8001;
@@ -120,9 +111,6 @@ http {
         
         server_name             plex.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6002;
             proxy_redirect      off;
@@ -139,9 +127,6 @@ http {
         
         server_name             tautulli.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6003;
             proxy_redirect      off;
@@ -157,9 +142,6 @@ http {
         listen                  443 ssl http2;
         
         server_name             movies.davydehaas.nl;
-        
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
 
         location / {
             proxy_pass          http://127.0.0.1:6004;
@@ -177,9 +159,6 @@ http {
         
         server_name             tv.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6005;
             proxy_redirect      off;
@@ -196,9 +175,6 @@ http {
         
         server_name             jackett.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6006;
             proxy_redirect      off;
@@ -215,9 +191,6 @@ http {
         
         server_name             deluge.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6007;
             proxy_redirect      off;
@@ -234,9 +207,6 @@ http {
         
         server_name             portainer.davydehaas.nl;
         
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
-
         location / {
             proxy_pass          http://127.0.0.1:6009;
             proxy_redirect      off;
@@ -251,9 +221,6 @@ http {
         listen                  443 ssl http2;
 
         server_name             fun4.davydehaas.nl;
-
-        ssl_certificate         /certs/live/davydehaas.nl/fullchain.pem;
-        ssl_certificate_key     /certs/live/davydehaas.nl/privkey.pem;
 
         location / {
             proxy_pass          http://127.0.0.1:4052;


### PR DESCRIPTION
Aangezien de ssl configuratie voor bijna alle servers hetzelfde is, kan je ze automatisch vanuit het http-block overnemen. De override bij wanneer040.nl zou nog moeten werken.

Overigens zijn bijna alle proxy_* argumenten ook overal hetzelfde, die kan je in een apart bestand stoppen en includen, maar ik heb nog niet zover met Docker gewerkt om nog extra bestanden toe te voegen.